### PR TITLE
Create an executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ ENV/
 # Cache
 __pycache__
 
+# PyInstaller
+*.manifest
+*.spec
+build/
+dist/
+
 # macOS-specific
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ This is an opinionated generator and will (by default) set the severity to every
 
 ## Usage
 
-First, you'll have to generate a `rules.json` file, which is just a file of all the rules. We're doing this because
-there's no reason to run a costly (and lengthy) HTTP operation every time. You can regenerate it as many times as you
-like.
+First, create the virtual environment and install dependencies from `requirements.txt`. Next, run the PyInstaller in
+order to produce an executable. You can name it whatever you want, `analysis-gen` is what I'll call it.
 
 ```bash
 # Create virtual environment and install dependencies
@@ -23,23 +22,38 @@ python3 -m venv venv
 source venv/bin/activate
 pip3 install -r requirements.txt
 
-# Run setup.py script
-python3 setup.py
+# Generate an executable
+pyinstaller --onefile --name=analysis-gen main.py
 ```
 
-Now you can use the `main.py` script. Use `--help` flag to see how it works.
+This should produce a CLI executable found in `dist/analysis-gen`. At this point, you can use it however you like. My
+suggestion is to create an alias.
 
 ```bash
-python3 main.py --help
+alias analysis-gen="/absolute/path/to/dist/analysis-gen"
 ```
 
-You need to provide the absolute path to the directory in which you want to generate the `analysis_options.yaml` file.
-Then, with the `--rule-sets` flag, you choose one of the three preferred rule sets. Lastly, with `--soft-mode` turned
-on, you set the severity of each rule to a `warning`, not an `error` (which is the default severity).
+If you want to learn how to use the CLI, refer to the help message (`analysis-gen --help`):
+
+```
+$ analysis-gen --help
+usage: analysis-gen [-h] [-r {core,recommended,flutter}] -p PATH [-s]
+
+Tool for automatically populating analysis_options.yaml file with all the available linting rules described by the official documentation.
+
+options:
+  -h, --help            show this help message and exit
+  -r {core,recommended,flutter}, --rule-set {core,recommended,flutter}
+                        Sets the rule set that analysis_options.yaml will contain. Defaults to core.
+  -p PATH, --path PATH  Absolute path to where you want to generate the analysis_options.yaml file
+  -s, --soft-mode       Sets the severity of enabled linting rules to "warning"
+```
 
 ## Further information and details
 
-*Disclaimer: this section is heavily based on the official documentation on linting rules.*
+*Disclaimer: this section is copied from the official documentation. No need to reinvent the wheel if Google already
+wrote things concisely enough. Knowing that people typically don't click on the links, I took some liberty to bring the
+documentation to you.*
 
 Some rules can be fixed automatically using **quick fixes**. A quick fix is an automated edit targeted at fixing the
 issue reported by the linter rule. If the rule has a quick fix, it can be applied

--- a/main.py
+++ b/main.py
@@ -1,10 +1,14 @@
 from src.cli import CLI
+from src.scraper import Scraper
 from src.yaml_helper import YAMLHelper
 
 
 def main():
     rule_set, path, for_softies = CLI.parse_arguments()
-    YAMLHelper.generate_analysis_options(path=path, rule_set=rule_set, soft_mode=for_softies)
+    YAMLHelper.generate_analysis_options(path=path,
+                                         rules=Scraper.find_all_rules(),
+                                         rule_set=rule_set,
+                                         soft_mode=for_softies)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+altgraph==0.17.3
 beautifulsoup4==4.11.1
+macholib==1.16.2
+pyinstaller==5.6.2
+pyinstaller-hooks-contrib==2022.13
 soupsieve==2.3.2.post1

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from src.parser import Parser
-
-if __name__ == '__main__':
-    rules = Parser.find_all_rules()
-    Parser.pack_rules_to_json(rules)

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -1,6 +1,4 @@
 import urllib.request
-from json import dumps
-from os import getcwd
 
 from bs4 import BeautifulSoup, Tag
 
@@ -8,10 +6,10 @@ from src.models.enums import RuleSetEnum, MaturityLevelEnum
 from src.models.rule_model import RuleModel
 
 
-class Parser:
+class Scraper:
     @staticmethod
     def find_all_rules() -> list[RuleModel]:
-        html: str = Parser.__get_documentation_html()
+        html: str = Scraper.__get_documentation_html()
 
         soup = BeautifulSoup(html, 'html.parser')
         rule_models: list[RuleModel] = []
@@ -74,11 +72,6 @@ class Parser:
                     ))
 
         return rule_models
-
-    @staticmethod
-    def pack_rules_to_json(rules: list[RuleModel]):
-        with open(f'{getcwd()}/rules.json', 'w') as file:
-            file.write(dumps([rule.to_object() for rule in rules]))
 
     @staticmethod
     def __get_documentation_html() -> str:

--- a/src/yaml_helper.py
+++ b/src/yaml_helper.py
@@ -1,9 +1,6 @@
-from json import load
-from os import getcwd
 from typing import TextIO
 
-from src.models.enums import RuleSetEnum, maturity_level_from_value, MaturityLevelEnum, \
-    rule_set_from_list
+from src.models.enums import RuleSetEnum, MaturityLevelEnum
 from src.models.rule_model import RuleModel
 
 lints_core_import = 'include: package:lints/core.yaml'
@@ -22,7 +19,7 @@ analyzer:
 
 class YAMLHelper:
     @staticmethod
-    def generate_analysis_options(path: str, rule_set: RuleSetEnum, soft_mode: bool) -> None:
+    def generate_analysis_options(path: str, rules: list[RuleModel], rule_set: RuleSetEnum, soft_mode: bool) -> None:
         with open(f'{path}/analysis_options.yaml', 'w') as file:
             match rule_set:
                 case RuleSetEnum.CORE:
@@ -37,25 +34,7 @@ class YAMLHelper:
             file.write('\n')
             file.write(analyzer_section)
 
-            all_rules = YAMLHelper.__load_rules_from_file()
-            YAMLHelper.__write_rules_to_file(rules=all_rules, rule_set=rule_set, soft_mode=soft_mode, file=file)
-
-    @staticmethod
-    def __load_rules_from_file() -> list[RuleModel]:
-        with open(f'{getcwd()}/rules.json', 'r') as file:
-            raw_json: list[dict] = load(file)
-            rules: list[RuleModel] = []
-            for item in raw_json:
-                rule = RuleModel(
-                    id=item['id'],
-                    description=item['description'],
-                    has_quick_fix=item['has_quick_fix'],
-                    rule_sets=rule_set_from_list(item['rule_sets']),
-                    maturity=maturity_level_from_value(item['maturity_level'])
-                )
-                rules.append(rule)
-
-        return rules
+            YAMLHelper.__write_rules_to_file(rules=rules, rule_set=rule_set, soft_mode=soft_mode, file=file)
 
     @staticmethod
     def __write_rules_to_file(rules: list[RuleModel], rule_set: RuleSetEnum, soft_mode: bool, file: TextIO) -> None:


### PR DESCRIPTION
Changelog
1. We no longer persist `rules.json`. After waking up and thinking about it twice, I figured that an average Joe will probably forget to keep the file regularly updated. This means it's better to run the scraper every time we want to generate `analysis_options.yaml`.
2. Add instructions on how to build an executable with PyInstaller. No need to go further than that, as everyone should be able to figure out how to create an alias in their OS + what if a person doesn't want to use an alias? So, let the people decide how they wanna use the project.

Closes #3.
